### PR TITLE
ESP32 IDF v4.2 compile fix

### DIFF
--- a/unishox2.c
+++ b/unishox2.c
@@ -377,7 +377,7 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
   byte state;
 
   int l, ll, ol;
-  char c_in, c_next;
+  unsigned int c_in, c_next;
   int prev_uni;
   byte is_upper, is_all_upper, is_sentence_start;
 


### PR DESCRIPTION
Using `char` for `c_in` limits it to 8-bit boundaries. Updated to `unsigned int` for 32-bit processes.  

ESP32 compile error resolved:
```gcc
unishox2.c:576:46: error: array subscript has type 'char' [-Werror=char-subscripts]
         ol = append_code(out, ol, usx_code_94[c_in], &state, usx_hcodes, usx_hcode_lens);
```